### PR TITLE
Base link list text border colors on the pillar themes.

### DIFF
--- a/src/scss/components/_box-menu.scss
+++ b/src/scss/components/_box-menu.scss
@@ -30,6 +30,22 @@
       border-right-color: $yellow;
     }
   }
+
+  &.unrestricted-giving {
+    background-color: $color-unrestricted-giving;
+
+    .box-menu__list {
+      border-right-color: $blue-light;
+    }
+  }
+
+  &.capital-projects {
+    background-color: $color-capital-projects;
+
+    .box-menu__list {
+      border-right-color: $blue-light;
+    }
+  }
 }
 
 .box-menu__list {

--- a/src/scss/components/_campaign-section-stats.scss
+++ b/src/scss/components/_campaign-section-stats.scss
@@ -44,6 +44,14 @@
         &.experience {
             background-color: $brown;
         }
+
+        &.unrestricted-giving {
+            background-color: $color-unrestricted-giving;
+        }
+
+        &.capital-projects {
+            background-color: $color-capital-projects;
+        }
     }
 }
 

--- a/src/scss/components/_media-object.scss
+++ b/src/scss/components/_media-object.scss
@@ -34,6 +34,14 @@
   &.experience {
     border-top-color: $color-experience;
   }
+
+  &.unrestricted-giving {
+    border-top-color: $color-unrestricted-giving;
+  }
+
+  &.capital-projects {
+    border-top-color: $color-capital-projects;
+  }
 }
 
 .media-object__image {

--- a/src/scss/components/_two-col-linked-list.scss
+++ b/src/scss/components/_two-col-linked-list.scss
@@ -26,17 +26,25 @@
             @include breakpoint(lg) {
                 padding-top: $spacing-4;
             }
-        }
 
-        &:first-child {
-            a {
-                border-top-color: #1F9F8B;
+            &.access {
+                border-top-color: $color-access;
             }
-        }
-
-        &:nth-child(2) {
-            a {
-                border-top-color: #022543;
+            
+            &.academic-excellence {
+                border-top-color: $color-academic-excellence;
+            }
+        
+            &.experience {
+                border-top-color: $color-experience;
+            }
+        
+            &.unrestricted-giving {
+                border-top-color: $color-unrestricted-giving;
+            }
+        
+            &.capital-projects {
+                border-top-color: $color-capital-projects;
             }
         }
     }

--- a/src/twig/paragraphs/two-col-linked-list.twig
+++ b/src/twig/paragraphs/two-col-linked-list.twig
@@ -1,6 +1,6 @@
 <div class="container two-col-linked-list">
     <ul class="row">
-        <li class="col-6"><a>Unrestricted Giving</a></li>
-        <li class="col-6"><a>Capital Projects</a></li>
+        <li class="col-6"><a class="unrestricted-giving">Unrestricted Giving</a></li>
+        <li class="col-6"><a class="capital-projects">Capital Projects</a></li>
     </ul>
 </div>


### PR DESCRIPTION
In the Drupal site we'll base the color for each of the links in a link list on the destination URL. I changed this up so that the top border is colored according to its theme based on a class rather than the first and second ones always being the colors for unrestricted giving and capital projects.